### PR TITLE
ensure terminate is a bool

### DIFF
--- a/gardenbot_env.py
+++ b/gardenbot_env.py
@@ -64,7 +64,7 @@ class GardenBotEnv(gym.Env):
             reward -= 2  # Neglect
 
         # Done if plant dies
-        terminated = plant_health <= 0
+        terminated = bool(plant_health <= 0)
 
         self.state = np.array([soil_moisture, nutrient_level, pest_threat, plant_health], dtype=np.float32)
         return self.state, reward, terminated, False, {}


### PR DESCRIPTION
the SB3 check_env noticed that terminate was non-bool; a simple type wrapper fixed this!